### PR TITLE
Fix device launch by cleaning Info.plist

### DIFF
--- a/MacMirroring iPhone/Resources/Info.plist
+++ b/MacMirroring iPhone/Resources/Info.plist
@@ -31,10 +31,6 @@
 				<dict>
 					<key>UISceneConfigurationName</key>
 					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
@@ -43,10 +39,6 @@
 	<true/>
 	<key>UILaunchScreen</key>
 	<dict/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Summary
- remove scene delegate and storyboard references from iPhone target
- drop armv7-only device requirement

## Testing
- `swift --version`
